### PR TITLE
 change repo name from authentication-tech-docs to tech-docs in tdt config

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -12,7 +12,7 @@ phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
-  GitHub: https://github.com/govuk-one-login/authentication-tech-docs
+  GitHub: https://github.com/govuk-one-login/tech-docs
   Support: https://docs.sign-in.service.gov.uk/support/
 
 # Links to show in the page footer
@@ -37,7 +37,7 @@ prevent_indexing: true
 
 # Contribution banner
 show_contribution_banner: true
-github_repo: govuk-one-login/authentication-tech-docs # used to generate links in the contribution banner
+github_repo: govuk-one-login/tech-docs # used to generate links in the contribution banner
 github_branch: main
 
 owner_slack_workspace: gds


### PR DESCRIPTION
## Why

The repository has recently changed name from govuk-one-login/authentication-tech-docs to govuk-one-loging/tech-docs

## What

Update the tech docs template configuration to generate links to the github repo to point to the new repo name.

## Technical writer support

No

## How to review

- 'git checkout fix-repo-name`
- `./preview-with-docker.sh`
- check the links work using `http://localhost:4567`

## Changelog

No changelog required

## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [X] Where there is any overlap I have updated or opened a PR for corresponding changes
