### PR TITLE
Rename repo

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -12,7 +12,7 @@ phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
-  GitHub: https://github.com/govuk-one-login/authentication-tech-docs
+  GitHub: https://github.com/govuk-one-login/tech-docs
   Support: https://docs.sign-in.service.gov.uk/support/
 
 # Links to show in the page footer
@@ -37,7 +37,7 @@ prevent_indexing: true
 
 # Contribution banner
 show_contribution_banner: true
-github_repo: govuk-one-login/authentication-tech-docs # used to generate links in the contribution banner
+github_repo: govuk-one-login/tech-docs # used to generate links in the contribution banner
 github_branch: main
 
 owner_slack_workspace: gds

--- a/preview-with-docker.sh
+++ b/preview-with-docker.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -e
 
-docker build . --tag authentication-tech-docs
+docker build . --tag tech-docs
 
-docker run -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/docs -it authentication-tech-docs
+docker run -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/docs -it tech-docs

--- a/template.yaml
+++ b/template.yaml
@@ -231,7 +231,7 @@ Resources:
         - Key: Service
           Value: ci/cd
         - Key: Source
-          Value: govuk-one-login/authentication-tech-docs/template.yaml
+          Value: govuk-one-login/tech-docs/template.yaml
 
   TaskExecutionRole:
     Type: AWS::IAM::Role
@@ -265,7 +265,7 @@ Resources:
         - Key: Service
           Value: ci/cd
         - Key: Source
-          Value: govuk-one-login/authentication-tech-docs/template.yaml
+          Value: govuk-one-login/tech-docs/template.yaml
 
 
   # Application Load balancing
@@ -299,7 +299,7 @@ Resources:
         - Key: Service
           Value: ci/cd
         - Key: Source
-          Value: govuk-one-login/authentication-tech-docs/template.yaml
+          Value: govuk-one-login/tech-docs/template.yaml
 
   ApplicationLoadBalancerTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -326,7 +326,7 @@ Resources:
         - Key: Service
           Value: ci/cd
         - Key: Source
-          Value: govuk-one-login/authentication-tech-docs/template.yaml
+          Value: govuk-one-login/tech-docs/template.yaml
 
   ApplicationLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -377,7 +377,7 @@ Resources:
         - Key: Service
           Value: ci/cd
         - Key: Source
-          Value: govuk-one-login/authentication-tech-docs/template.yaml
+          Value: govuk-one-login/tech-docs/template.yaml
 
   ApplicationLoadBalancerSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress


### PR DESCRIPTION
## Why

I renamed the repo to `tech-docs`
Turned out there were a few things missed in the deploy script

## What

also updated some canonical links along the way

