### PR TITLE
Update deploy-to-aws.yml

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
     steps:
       - name: Check out repository code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin @v4
       - name: Install Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # pin@v1
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # pin @v1
         with:
           bundler-cache: true
           ruby-version: 3.2.3
@@ -32,7 +32,7 @@ jobs:
         run: bundle exec middleman build
 
       - name: Upload to ECR and tag
-        uses: govuk-one-login/devplatform-upload-action-ecr@2670d3fde00e5e9eed187135e853f273763cab02 # pin@1.2.4
+        uses: govuk-one-login/devplatform-upload-action-ecr@2670d3fde00e5e9eed187135e853f273763cab02 # pin @1.2.4
         with:
           role-to-assume-arn: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
Fixing pinning syntax so that the dependencies graph in Github

## Why

Change the pinning syntax so that dependencies in GitHub can report against the version.

## What

Add a space between the comment and the version.

## Technical writer support

No.

## How to review

Check that dependabot syntax still remains compatible, and check GH that the dependency graph points at the version, rather than the commit sha.

