### PR TITLE
AP-297🪳Fix broken markdown link on the How it works pages - point 8

### DIFF
--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -39,6 +39,7 @@
 [integrate.identity-proving]: /integrate-with-integration-environment/prove-users-identity/
 
 <!-- integrating links (logging out) -->
+[integrate.make-logout-request]: /integrate-with-integration-environment/managing-your-users-sessions/#log-your-user-out-of-gov-uk-one-login
 
 <!-- post integrating links -->
 [integrate.test-connection]: /test-your-integration/


### PR DESCRIPTION
[AP-297](https://govukverify.atlassian.net/browse/AP-297)
## Why

Broken link in the how it works secion

## What
<img width="1117" alt="image" src="https://github.com/govuk-one-login/tech-docs/assets/34273121/6b6a7e64-2e9a-4998-87ba-d7943b2cdc33">

fix the link in point 8 of https://docs.sign-in.service.gov.uk/how-gov-uk-one-login-works/#understand-the-technical-flow-gov-uk-one-login-uses to refer to a markdown reference in the partials/_links.erb


## Technical writer support

Do you need a tech writer's support, for example to review your PR? - YES

## How to review

- check out the branch 
- run `./build-with-docker.sh to check links`
- run `./preview-with-docker.sh`
- check https://localhost:3000/how-gov-uk-one-login-works/#understand-the-technical-flow-gov-uk-one-login-uses is now correct

## Changelog

trivial correction so no changelog required
## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [X] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-297]: https://govukverify.atlassian.net/browse/AP-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ