### PR TITLE
BAU: Remove updated_at fields from userinfo response

### DIFF
--- a/source/integrate-with-integration-environment/authenticate-your-user.html.md.erb
+++ b/source/integrate-with-integration-environment/authenticate-your-user.html.md.erb
@@ -430,8 +430,7 @@ Content-Type: application/json
   "email": "test@example.com",
   "email_verified": true,
   "phone_number": "01406946277",
-  "phone_number_verified": true,
-  "updated_at":1311280970
+  "phone_number_verified": true
 }
 ```
 

--- a/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
+++ b/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
@@ -30,7 +30,6 @@ Content-Type: application/json
   "email_verified": true,
   "phone": "01406946277",
   "phone_verified": true,
-  "updated_at": 1311280970,
   "https://vocab.account.gov.uk/v1/coreIdentityJWT": <JWT>,
   "https://vocab.account.gov.uk/v1/address": [
     {
@@ -273,7 +272,6 @@ Content-Type: application/json
   "email_verified": true,
   "phone_number": "01406946277",
   "phone_number_verified": true,
-  "updated_at":1311280970,  
   "https://vocab.account.gov.uk/v1/returnCode": [
     {
       "code": "B"


### PR DESCRIPTION
## Why

We do not return updated_at in the userinfo response
## What

Remove updated_at
## Technical writer support

Do you need a tech writer's support, for example to review your PR?

## How to review

Tell reviewers how to assess your changes.

## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes
