### PR TITLE
VPC stack is updated to export firewall subnets

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -278,12 +278,10 @@ Resources:
       SecurityGroups:
         - !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
       Subnets:
-        - subnet-045dd4d5c1dd1b35d #hard coded as not exposed by VPC (FirewallSubnetB)
-        - subnet-0f5b4d93d9fd6aab0 #hard coded as not exposed by VPC (FirewallSubnetA)
-        #- Fn::ImportValue:
-        #    !Sub "${VpcStackName}-FirewallSubnetIdA"
-        #- Fn::ImportValue:
-        #    !Sub "${VpcStackName}-FirewallSubnetIdB"
+        - Fn::ImportValue:
+            !Sub "${VpcStackName}-FirewallSubnetIdA"
+        - Fn::ImportValue:
+            !Sub "${VpcStackName}-FirewallSubnetIdB"
       Type: application
 
       LoadBalancerAttributes:


### PR DESCRIPTION
This means we can remove the hard coded subnet values from the stack and replace with refs

## Why

The hard coded subnets were a temporary fix, this re-pays that tech debt

## What

Remove a hard coded value, and replace with a reference

## Technical writer support

No

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes
