### PR TITLE
Fix depbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
   - package-ecosystem: docker
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
-    directory: "/.github/"
+    directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
## Why

Dependabot is looking at the wrong directory for github actions so we're not getting helpful offers of updates.

## What

Describe the changes you're proposing.

## Technical writer support

Nope

## How to review

Cross reference with here:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions
