### PR TITLE
SPT-811: Update to show absolute URI in assertionMethod

### DIFF
--- a/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
+++ b/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
@@ -180,7 +180,7 @@ This is an example of a web DID document published by GOV.UK One Login:
   "id": "did:web:identity.account.gov.uk",
   "assertionMethod": [
     {
-      "id": "b7863b6926193d93b48808cbabcbc8a414d0080f81c8779c0a54491551a35816",
+      "id": "did:web:identity.account.gov.uk#b7863b6926193d93b48808cbabcbc8a414d0080f81c8779c0a54491551a35816",
       "type": "JsonWebKey",
       "controller": "did:web:identity.account.gov.uk",
       "publicKeyJwk": {
@@ -214,7 +214,7 @@ Follow the steps below to use the `kid` to determine which public key from the D
   * Integration: [https://identity.integration.account.gov.uk/.well-known/did.json](https://identity.integration.account.gov.uk/.well-known/did.json) 
   * Production: [https://identity.account.gov.uk/.well-known/did.json](https://identity.account.gov.uk/.well-known/did.json). 
 1. Make sure the controller ID matches the `id` in the DID document.
-1. Find the object in `assertionMethods` which has an `id` field matching the unique key ID from the `kid` in the DID document. If there are multiple keys in the DID document, GOV.UK One Login is in the process of rotating its keys. If there’s a key without a matching `id`, do not trust the identity and contact GOV.UK One Login to report an incident.
+1. Find the object in `assertionMethods` which has an `id` field matching the `kid` from the JWT header. If there are multiple keys in the DID document, GOV.UK One Login is in the process of rotating its keys. If there’s a key without a matching `id`, do not trust the identity and contact GOV.UK One Login to report an incident.
 1. Use the `publicKeyJwk` object of the key you want to use to verify the signature. 
 
 #### Cache the DID document 


### PR DESCRIPTION
## Why

The `id` field should be an absolute URI. According to the [DID Core spec](https://www.w3.org/TR/did-core/#verification-methods)

## What

Update the example DID document and the documentation about how to use the `kid` to match the correct key.

## Technical writer support

A quick look, hopefully.

## Confirm

- [ ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
