### PR TITLE
AP-335 redirect the old /go-live link used by the onboarding manual to the n…

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -35,6 +35,11 @@ max_toc_heading_level: 3
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: true
 
+# redirection of old addresses to new pages
+redirects:
+  /go-live: /configure-for-production
+
+
 # Contribution banner
 show_contribution_banner: true
 github_repo: govuk-one-login/tech-docs # used to generate links in the contribution banner


### PR DESCRIPTION
[AP-335](https://govukverify.atlassian.net/browse/AP-335)

## Why

The onboarding manual has links to the old `/go-live` page, this has been replaced with `/configure-for-production/` in the docs so we need to gracefully redirect users of the old link to the new page

## What

A simple redirect configuration in `config/tech-docs.yml` 

## Technical writer support

Do you need a tech writer's support, for example to review your PR? *YES*

## How to review

- clone the branch 
- build the branch using `./build-with-docker.sh`
- host locally `cd build; python -m http.server 3000; open http://localhost:3000/go-live
- ensure the redirect works

## Changelog

trivial change that does not warrant a change log entry
## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-335]: https://govukverify.atlassian.net/browse/AP-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ