### PR TITLE
AP-355 Ensure generaAPted redirect are served as text/html mime type

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -16,7 +16,7 @@ http {
     }
 
     include mime.types;
-    default_type application/octet-stream;
+    default_type text/html;
     gzip_types text/plain text/xml text/css
                text/comma-separated-values
                text/javascript application/x-javascript

--- a/preview-with-nginx.sh
+++ b/preview-with-nginx.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set -e
+
+# generate the build directory of static content and run the html-proofer
+./build-with-docker.sh
+
+# build nginx container with build content
+docker build -f DockerfileAWS --tag tech-docs-nginx .
+
+# run nginx
+docker run -p 80:80 -it tech-docs-nginx


### PR DESCRIPTION
[AP-355](https://govukverify.atlassian.net/browse/AP-335)

## Why

Explain why these changes are necessary.

## What

We need to ensure that page redirects configured in config/tech-docs.yml are served with the right mime type rather than as binaries and downloaded

- Update default mime type in nginx.conf
- add a helper script preview-with-nginx.sh to build content, dockerize nginx and run locally on port 80

## Technical writer support

Do you need a tech writer's support, for example to review your PR? *YES* 

## How to review

- `git clone https://github.com/govuk-one-login/tech-docs`
- `git checkout branch` 
- build, dockerize and run ngin in a container locally using`./preview-with-nginx.sh`
- open `http://localhost/go-live` and sure it redirects correctly

## Changelog

This is a bugfix pr to address an issue with redirects so not required

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [x] Where there is any overlap I have updated or opened a PR for corresponding changes
