### PR TITLE
AP-344 - Enable indexing of tech-docs content

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -33,7 +33,7 @@ collapsible_nav: true
 max_toc_heading_level: 3
 
 # Prevent robots from indexing (e.g. whilst in development)
-prevent_indexing: true
+prevent_indexing: false
 
 # redirection of old addresses to new pages
 redirects:


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/AP-344 

## Why

Our technical documentation is not indexed by search engines

## What

Modify the `config/tech-docs.yml` to allow indexing with `prevent_indexing: false`

## Technical writer support

Do you need a tech writer's support, for example to review your PR? *YES*

## How to review

- build the new content using `/.build-with-docker.sh`
- review `build/index.html` and ensure it does not contain a meta rule to defeat indexing -> `<meta name="robots" content="noindex" />`
- test the site works using `./preview-with-docker.sh`

## Changelog

none required 

## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [X] Where there is any overlap I have updated or opened a PR for corresponding changes
