### PR TITLE
Fixed incorrect word in DID document process

### DIFF
--- a/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
+++ b/source/integrate-with-integration-environment/prove-users-identity.html.md.erb
@@ -214,7 +214,7 @@ Follow the steps below to use the `kid` to determine which public key from the D
   * Integration: [https://identity.integration.account.gov.uk/.well-known/did.json](https://identity.integration.account.gov.uk/.well-known/did.json) 
   * Production: [https://identity.account.gov.uk/.well-known/did.json](https://identity.account.gov.uk/.well-known/did.json). 
 1. Make sure the controller ID matches the `id` in the DID document.
-1. Find the object in `assertionMethods` which has an `id` field matching the `kid` from the JWT header. If there are multiple keys in the DID document, GOV.UK One Login is in the process of rotating its keys. If there’s a key without a matching `id`, do not trust the identity and contact GOV.UK One Login to report an incident.
+1. Find the object in `assertionMethods` which has an `id` field matching the `kid` from the JWT header. If there are multiple keys in the DID document, GOV.UK One Login is in the process of rotating its keys. If there’s a `kid` without a matching `id`, do not trust the identity and contact GOV.UK One Login to report an incident.
 1. Use the `publicKeyJwk` object of the key you want to use to verify the signature. 
 
 #### Cache the DID document 


### PR DESCRIPTION
## Why

The DID process documentation used the word key when it should have been kid

## What

Replace the word key with kid

## Technical writer support

None required

## How to review

Single word change in DID validation process

## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [X] Where there is any overlap I have updated or opened a PR for corresponding changes
