### PR TITLE
AP-415 - change references to rp-reference repository to onboarding-examples

### DIFF
--- a/source/before-integrating/integrating-third-party-platform.html.md.erb
+++ b/source/before-integrating/integrating-third-party-platform.html.md.erb
@@ -16,7 +16,7 @@ GOV.UK One Login will update this page with information on integrating with thir
 
 | Platform | How to integrate with GOV.UK One Login                                                                                                                                                                                                                                                                                                                                            |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Salesforce       | You'll need to build an authentication provider plugin to integrate using Salesforce. <br></br><br></br> There's further [guidance on building an authentication provider plugin](https://github.com/govuk-one-login/rp-reference/blob/main/clients/Apex-Salesforce/README.md) (opens separate repository). 
+| Salesforce       | You'll need to build an authentication provider plugin to integrate using Salesforce. <br></br><br></br> There's further [guidance on building an authentication provider plugin](https://github.com/govuk-one-login/onboarding-examples/blob/main/clients/Apex-Salesforce/README.md) (opens separate repository). 
 
 
 

--- a/source/test-your-integration/build-mocks.html.md.erb
+++ b/source/test-your-integration/build-mocks.html.md.erb
@@ -41,7 +41,7 @@ To set up your local development environment, you can do one or both of these op
 
 There are 2 types of test data: 
 
-* [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/rp-reference/tree/main/example-data) to help you build your mocks
+* [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/onboarding-examples/tree/main/example-data) to help you build your mocks
 * fictional users and their knowledge-based verification (KBV) answers to help you create a GOV.UK One Login and test your journeys - you'll need to [contact GOV.UK One Login to access test user data](mailto:govuk-one-login@digital.cabinet-office.gov.uk)
 
 

--- a/source/test-your-integration/using-integration-for-testing.html.md.erb
+++ b/source/test-your-integration/using-integration-for-testing.html.md.erb
@@ -39,7 +39,7 @@ Before you can test on our integration environment, you must:
 
 * have [registered your service to use GOV.UK One Login][integrate.register-your-service]
 * have built an application to work with GOV.UK One Login
-* have accessed the [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/rp-reference/tree/main/example-data)
+* have accessed the [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/onboarding-examples/tree/main/example-data)
 * have contacted GOV.UK One Login to access the fictional users and their knowledge-based verification (KBV) answers to help you test your journeys
 * use the integration environment’s login details when prompted to log in – you’ll have received these when you registered your service to use GOV.UK One Login
 
@@ -81,7 +81,7 @@ When conducting automated testing, the multi-factor authentication may block you
 1. Select **Authenticator app for smartphone, tablet or computer**. 
 1. Select the **I cannot scan the QR code** dropdown.
 1. Make a note of the secret key which appears in the dropdown – some authenticator apps call the secret key a ‘code’.
-1. Use this secret key to generate a one-time code using a scripting language within your test – there’s an [example of how to generate a one-time code using TypeScript](https://github.com/govuk-one-login/rp-reference/blob/main/tools/totp/totp.ts) in our GitHub repo. 
+1. Use this secret key to generate a one-time code using a scripting language within your test – there’s an [example of how to generate a one-time code using TypeScript](https://github.com/govuk-one-login/onboarding-examples/blob/main/tools/totp/totp.ts) in our GitHub repo. 
 
 ## Conducting end-to-end user testing against the integration environment
 ### Test successful user journeys


### PR DESCRIPTION
[AP-415](https://govukverify.atlassian.net/browse/AP-415)
## Why

The name of the rp-reference repository changed to onboarding-examples

## What

update all links to use the new repository name

- before-integrating/integrating-third-party-platform.html.md.erb
- test-your-integration/using-integration-for-testing.html.md.erb
- test-your-integration/build-mocks.html.md.erb

## Technical writer support

Do you need a tech writer's support, for example to review your PR? YES

## How to review

- git clone the branch
- ./preview-with-docker.sh
- go to http://localhost:4567
- review the pages affected


## Changelog

no, this is a small thing

## Confirm

- [x] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-415]: https://govukverify.atlassian.net/browse/AP-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ