### PR TITLE
fix references to the onboarding-examples

### DIFF
--- a/source/before-integrating/integrating-third-party-platform.html.md.erb
+++ b/source/before-integrating/integrating-third-party-platform.html.md.erb
@@ -16,7 +16,7 @@ GOV.UK One Login will update this page with information on integrating with thir
 
 | Platform | How to integrate with GOV.UK One Login                                                                                                                                                                                                                                                                                                                                            |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Salesforce       | You'll need to build an authentication provider plugin to integrate using Salesforce. <br></br><br></br> There's further [guidance on building an authentication provider plugin](https://github.com/govuk-one-login/onboarding-examples/blob/main/clients/Apex-Salesforce/README.md) (opens separate repository). 
+| Salesforce       | You'll need to build an authentication provider plugin to integrate using Salesforce. <br></br><br></br> There's further [guidance on building an authentication provider plugin](https://github.com/govuk-one-login/onboarding-examples/blob/main/clients/salesforce-apex/README.md) (opens separate repository). 
 
 
 

--- a/source/test-your-integration/build-mocks.html.md.erb
+++ b/source/test-your-integration/build-mocks.html.md.erb
@@ -41,7 +41,7 @@ To set up your local development environment, you can do one or both of these op
 
 There are 2 types of test data: 
 
-* [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/onboarding-examples/tree/main/example-data) to help you build your mocks
+* [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/onboarding-examples/tree/main/data) to help you build your mocks
 * fictional users and their knowledge-based verification (KBV) answers to help you create a GOV.UK One Login and test your journeys - you'll need to [contact GOV.UK One Login to access test user data](mailto:govuk-one-login@digital.cabinet-office.gov.uk)
 
 

--- a/source/test-your-integration/using-integration-for-testing.html.md.erb
+++ b/source/test-your-integration/using-integration-for-testing.html.md.erb
@@ -39,7 +39,7 @@ Before you can test on our integration environment, you must:
 
 * have [registered your service to use GOV.UK One Login][integrate.register-your-service]
 * have built an application to work with GOV.UK One Login
-* have accessed the [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/onboarding-examples/tree/main/example-data)
+* have accessed the [example responses from the GOV.UK One Login API](https://github.com/govuk-one-login/onboarding-examples/tree/main/data)
 * have contacted GOV.UK One Login to access the fictional users and their knowledge-based verification (KBV) answers to help you test your journeys
 * use the integration environment’s login details when prompted to log in – you’ll have received these when you registered your service to use GOV.UK One Login
 


### PR DESCRIPTION
## Why

Correct links to the onboarding-examples repository to reflect the new forder structure

## What

Fix links

## Technical writer support

Do you need a tech writer's support, for example to review your PR? NO

## How to review

Tell reviewers how to assess your changes.

- `git clone`
- `./preview-with-nginx.sh`
- browse to `http://localhost`


## Changelog

no

## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
