### PR TITLE
Pin dependencies in the dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ EXPOSE 35729:35729
 WORKDIR /usr/src/gems
 
 COPY ./Gemfile /usr/src/gems
+COPY Gemfile.lock /usr/src/gems
 
 RUN apt-get update && apt-get install -y nodejs
 


### PR DESCRIPTION
## Why

This matches the deployed environment. There's currently a issue with a new version of a dependency that prevents local dev.

## What

Use the pinned version of gems in the local container



