### PR TITLE
AP-506 - Fix the post redirect logout url used against integration

### DIFF
--- a/source/configure-for-production/index.html.md.erb
+++ b/source/configure-for-production/index.html.md.erb
@@ -8,14 +8,12 @@ review_in: 6 months
 
 # Configure your service for production
 
-<%= warning_text('You must complete this process at least two weeks before you start using the production environment in private or public beta.') %>
+<%= warning_text('You must configure your service for production at least 2 weeks before you start using the production environment in private beta or public beta.') %>
 
 Before you can configure your service for production, you must [integrate with GOV.UK One Login's integration environment][integrate.integrate].
 
-The process for configuring your service for production is: 
-
-1. Confirm with your Engagement Manager that you need to configure your service in production – if you do not have an Engagement Manager, [complete the form to register your interest](https://www.sign-in.service.gov.uk/register).
-1. You only need to send your Engagement Manager the client ID of the client you’ve been testing in your integration configuration. The GOV.UK One Login team will send you a draft configuration in JSON format including the new client ID for your production service. 
+1. Tell your Engagement Manager that you need to configure your service in production – if you do not have an Engagement Manager, [complete the form to register your interest](https://www.sign-in.service.gov.uk/register).
+1. You only need to send your Engagement Manager the service name and client ID of the client you’ve been testing in your integration configuration. The GOV.UK One Login team will send you a draft configuration in JSON format including the new client ID for your production service. 
 1. Update the JSON configuration by replacing the placeholder values with your service's configuration. There’s [guidance on understanding the JSON configuration](/configure-for-production/#use-the-table-to-understand-the-json-configuration). 
 1. Send your modified JSON configuration back to GOV.UK One Login by email. The GOV.UK One Login team will check your production configuration and contact you if we need more information.
 1. Configure the new client ID into your own application code and deploy to your production environment. 

--- a/source/configure-for-production/index.html.md.erb
+++ b/source/configure-for-production/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Configure your service for production
 weight: 3.5
-last_reviewed_on: 2024-09-06
+last_reviewed_on: 2025-02-20
 review_in: 6 months
 ---
 
@@ -11,18 +11,15 @@ Before you can configure your service for production, you must [integrate with G
 
 The process for configuring your service for production is: 
 
-1. Contact your Engagement Manager – if you do not have an Engagement Manager, [complete the form to register your interest](https://www.sign-in.service.gov.uk/register).
-1. Confirm with your Engagement Manager that you need to configure your service in production. Make sure you send the client ID of the client you’ve been testing in your integration configuration.
-1. The GOV.UK One Login team will send you a draft configuration in JSON format including the new client ID for your production service. 
-1. Fill in the JSON configuration by replacing the placeholder values with your service's configuration. There’s further [guidance on filling in your JSON configuration](/configure-for-production/#fill-in-your-json-configuration). 
-1. Send your modified JSON configuration back to GOV.UK One Login by email. 
-1. The GOV.UK One Login team will check your production configuration and contact you if we need more information.
+1. Confirm with your Engagement Manager that you need to configure your service in production – if you do not have an Engagement Manager, [complete the form to register your interest](https://www.sign-in.service.gov.uk/register).
+1. You only need to send your Engagement Manager the client ID of the client you’ve been testing in your integration configuration. The GOV.UK One Login team will send you a draft configuration in JSON format including the new client ID for your production service. 
+1. Update the JSON configuration by replacing the placeholder values with your service's configuration. There’s [guidance on understanding the JSON configuration](/configure-for-production/#use-the-table-to-understand-the-json-configuration). 
+1. Send your modified JSON configuration back to GOV.UK One Login by email. The GOV.UK One Login team will check your production configuration and contact you if we need more information.
 1. Configure the new client ID into your own application code and deploy to your production environment. 
 1. Test your application works in production. This could be a limited test with a small number of users or a limited private beta.
 
-## Fill in your JSON configuration
+## Use the table to understand the JSON configuration
 
-Use this table to help you fill in your JSON configuration.
 
 | Field | Notes |
 | :------ | :---- |
@@ -50,51 +47,6 @@ Use this table to help you fill in your JSON configuration.
 | `TestClient` | Leave this field as `false`.  |
 | `TokenAuthMethod` | Specify the token authentication method your service is using. This will be `private_key_jwt` or `client_secret_post`. <br><br>There’s further [guidance on using the correct token authentication method for your service](/before-integrating/use-correct-token-authentication-method/).   |
 
-This is an example production JSON for identity using `private_key_jwt`:
-
-```
-
-{
- “BackChannelLogoutUri”: “{BACKCHANNEL_LOGOUT_URI}”,
- "ClientID": "{CLIENT_ID}",
- "Claims": [
-  "https://vocab.account.gov.uk/v1/coreIdentityJWT",
-  "https://vocab.account.gov.uk/v1/address",
-  "https://vocab.account.gov.uk/v1/passport",
-  "https://vocab.account.gov.uk/v1/drivingPermit"
- ],
- "ClientName": "{CLIENT_NAME}",
- "ClientType": "web",
- "ConsentRequired": false,
- "Contacts": [
-  "{CONTACT_EMAIL}"
- ],
- "CookieConsentShared": false,
- "IdentityVerificationSupported": true,
- "IdTokenSigningAlgorithm": "ES256",
- "OneLoginService": false,
- "PostLogoutRedirectUrls": [
-  "{POST_LOGOUT_URL}"
- ],
- "PublicKey": "{PUBLIC_KEY}",
- "RedirectUrls": [
-  "{REDIRECT_URI}"
- ],
- "Scopes": [
-  "openid",
-  "email",
-  "phone"
- ],
- "SectorIdentifierUri": "{SECTOR_IDENTIFIER_URI}",
- "ServiceType": "MANDATORY",
- "SubjectType": "pairwise",
- "TestClient": false,
- "TestClientEmailAllowlist": [
- ],
- "TokenAuthMethod": "private_key_jwt"
-}
-
-```
 
 ## Use the production discovery endpoint
 

--- a/source/configure-for-production/index.html.md.erb
+++ b/source/configure-for-production/index.html.md.erb
@@ -5,7 +5,10 @@ last_reviewed_on: 2025-02-20
 review_in: 6 months
 ---
 
+
 # Configure your service for production
+
+<%= warning_text('You must complete this process at least two weeks before you start using the production environment in private or public beta.') %>
 
 Before you can configure your service for production, you must [integrate with GOV.UK One Login's integration environment][integrate.integrate].
 

--- a/source/configure-for-production/index.html.md.erb
+++ b/source/configure-for-production/index.html.md.erb
@@ -12,7 +12,7 @@ review_in: 6 months
 
 Before you can configure your service for production, you must [integrate with GOV.UK One Login's integration environment][integrate.integrate].
 
-1. Tell your Engagement Manager that you need to configure your service in production – if you do not have an Engagement Manager, [complete the form to register your interest](https://www.sign-in.service.gov.uk/register).
+1. Tell your Engagement Manager that you need to configure your service in production – if you do not have an Engagement Manager, [complete the form to register your interest](https://www.sign-in.service.gov.uk/register). You'll need to complete this form a minimum of 6 weeks before your go-live date. 
 1. You only need to send your Engagement Manager the service name and client ID of the client you’ve been testing in your integration configuration. The GOV.UK One Login team will send you a draft configuration in JSON format including the new client ID for your production service. 
 1. Update the JSON configuration by replacing the placeholder values with your service's configuration. There’s [guidance on understanding the JSON configuration](/configure-for-production/#use-the-table-to-understand-the-json-configuration). 
 1. Send your modified JSON configuration back to GOV.UK One Login by email. The GOV.UK One Login team will check your production configuration and contact you if we need more information.

--- a/source/quick-start.html.md.erb
+++ b/source/quick-start.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Quick start
 weight: 1.6
-last_reviewed_on: 2025-01-21
+last_reviewed_on: 2025-02-26
 review_in: 6 months
 ---
 
@@ -83,7 +83,7 @@ Before you start, make sure you have a:
     * a redirect URI: `http://localhost:8080/oidc/authorization-code/callback`
     * a public key (copy the static public key you created earlier from the `./public_key.pem` file, excluding the headers)
     * scopes: `openid`, `email`, `phone`
-    * a post logout redirect URI: `http://localhost:8080/oidc/logged-out`
+    * a post logout redirect URI: `http://localhost:8080/signed-out`
     * there's further [guidance on registering and managing your service](/before-integrating/register-and-manage-your-service/#register-and-manage-your-service) if you want to include additional fields
 
 #### Configure the example application 


### PR DESCRIPTION
## Why

Incorrect url

## What

change the post logout redirect to ``http://localhost:8080/signed-out` to match the example app in onboardfing-examples

## Technical writer support

Do you need a tech writer's support, for example to review your PR? NO

## How to review

- clone branch
- `./preview-with-docker.sh`
- review rendered page

## Changelog

not require

## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
