### PR TITLE
AP-506 - Fix post redirect logout

### DIFF
--- a/source/quick-start.html.md.erb
+++ b/source/quick-start.html.md.erb
@@ -83,7 +83,7 @@ Before you start, make sure you have a:
     * a redirect URI: `http://localhost:8080/oidc/authorization-code/callback`
     * a public key (copy the static public key you created earlier from the `./public_key.pem` file, excluding the headers)
     * scopes: `openid`, `email`, `phone`
-    * a post logout redirect URI: `http://localhost:8080/oidc/logged-out`
+    * a post logout redirect URI: `http://localhost:8080/signed-out`
     * there's further [guidance on registering and managing your service](/before-integrating/register-and-manage-your-service/#register-and-manage-your-service) if you want to include additional fields
 
 #### Configure the example application 

--- a/source/quick-start.html.md.erb
+++ b/source/quick-start.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Quick start
 weight: 1.6
-last_reviewed_on: 2025-01-21
+last_reviewed_on: 2025-02-26
 review_in: 6 months
 ---
 


### PR DESCRIPTION
[AP-506](https://govukverify.atlassian.net/browse/AP-506)

update the post redirect logout so that it works with the onboarding-examples/clients/nodejs app

## Why

Incompatible with the example application

## What

update post redirect logout to `http://localhost:8080/signed-out`

## Technical writer support

Do you need a tech writer's support, for example to review your PR? NO

## How to review

- clone branch
- `./preview-with-docker.sh`

## Changelog

none required

## Confirm

- [X] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes


[AP-506]: https://govukverify.atlassian.net/browse/AP-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ