### PR TITLE
adds interactive_mode content

### DIFF
--- a/source/gov-uk-one-login-simulator.html.md.erb
+++ b/source/gov-uk-one-login-simulator.html.md.erb
@@ -494,6 +494,50 @@ If you want to deploy the simulator using a host name or port other than `localh
 
 Modifying the simulator URL will affect other endpoints and any validation that includes these endpoints. For example, the token endpoint will become `${SIMULATOR_URL}/token`, so you need to update the expected audience of the client assertion to reflect this.
 
+### Returning multiple response configurations
+
+You can set the GOV.UK One Login simulator to return multiple response configurations. This can help you to test how your system handles different responses from GOV.UK One Login. 
+
+For example, you can fill in one response with passport and address data, but for  another request you could swap the passport data for driving license data. 
+
+To do this, set the environment variable `INTERACTIVE_MODE` to `true`. 
+
+With `INTERACTIVE_MODE` enabled, after you make the `/authorize` request you’ll see a form where you can add the expected response configuration.
+
+You must submit the `sub` field when filling in the form. All other fields are optional. 
+
+By default, the form is pre-populated with the same [response configuration the GOV.UK One Login simulator is configured with](https://github.com/govuk-one-login/simulator/blob/main/docs/configuration.md#response-configuration). You can overwrite each field with the expected values for the response configuration fields. 
+
+The form will show all possible configurable fields, even if the `/authorize` request you’re submitting does not include the [scope or claims](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#replace-the-placeholder-values-in-your-example) required for the simulator to return them. 
+
+For example, your `/authorize` request might not include the `https://vocab.account.gov.uk/v1/passport` claim, but the form will still include this field. However, the GOV.UK One Login simulator will only return the scopes or claims you include in your `/authorize` request.
+
+Any response configuration form fields that you do not submit will use the [pre-configured response fields](https://github.com/govuk-one-login/simulator/blob/main/docs/configuration.md#response-configuration).
+
+All values you submit through the form are [validated to the same level as values submitted to the ‘/config’ endpoint](https://github.com/govuk-one-login/simulator/blob/main/docs/configuration.md#response-configuration).
+
+You can find example JSON for identity claims in the [technical documentation](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#prove-your-user-39-s-identity) or in the [onboarding examples](https://github.com/govuk-one-login/onboarding-examples).
+
+Once you’ve entered the fields you’d like to test the responses for, select **Continue**. You will then be redirected to the `redirect_uri` from your `/authorize` request.
+
+When your service exchanges the `issued access_token` at the `/userinfo` endpoint, the simulator will return the response configuration you submitted in the form.
+
+If you submit an invalid field, you may see the following error response:
+
+```
+{
+  "error": "invalid_request",
+  "invalid_fields": [
+    {
+      "field": "a field name",
+      "msg": "an error message"
+    }
+  ]
+}
+```
+
+In this response, `field` tells you which of your submitted fields is invalid. If you see this error, check the data in the specified field. If you continue to see this error message contact the GOV.UK One Login team for support.
+
 ## Support and feedback
 
 [Raise a GitHub Issue with the GOV.UK One Login simulator](https://github.com/govuk-one-login/simulator/issues) if you:


### PR DESCRIPTION
Adds new content about running interactive_mode for multiple response configurations

## Why

Users can turn on `interactive_mode` to let them return multiple response configurations, but there's nothing in the tech docs about how to do it.

## What

We're adding new content to the tech docs to explain what `interactive_mode` is and how to use it.

## Technical writer support

Only to approve the PR - pre-i and 2i happened outside GitHub

## How to review

Tell reviewers how to assess your changes.

## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [ ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
