### PR TITLE
BAU: Update redcarpet to 3.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
+    redcarpet (3.6.1)
     rexml (3.3.9)
     rouge (3.30.0)
     ruby-rc4 (0.1.5)


### PR DESCRIPTION
## Why

This is a transitive dependency that's required in order for us to update thor, resolving a security vulnerability. 

## What

Updating `redcarpet` to 3.6.1
