### PR TITLE
GitHub Action badge added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Repository Status
+![AWS build and deploy](https://github.com/govuk-one-login/tech-docs/actions/workflows/deploy-to-aws.yml/badge.svg)
+
+
+
 # GOV.UK One Login technical documentation
 
 This repo contains documentation to help technologists at government departments onboard to GOV.UK One Login. It’s published using the Technical Documentation Template.


### PR DESCRIPTION
## Why

This PR is to help raise awareness of GitHub Action statuses directly on the repositories README, so that it easy to find out the status of a GitHub Action (e.g. Deployment to AWS) without having to navigate further into the repository or use an external system.

## What

The PR alters the repositories README file so that is has a new heading (Repository Status) and an status badge which reports if the GitHub Action for deploying to AWS is passing or failing.

## Technical writer support

No support required.

## How to review

Please check the branch preview of the README file to make sure the badge is displaying. The badge is created in Markdown and should be pointing to the workflow action called "deploy-to-aws.yaml".