### PR TITLE
State RSA restriction

### DIFF
--- a/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
+++ b/source/before-integrating/set-up-your-public-and-private-keys.html.md.erb
@@ -16,6 +16,8 @@ Your key pair will consist of a private key and its corresponding public key.
 
 You need to share your public key with GOV.UK One Login so it can validate the signature on each JWT your service sends.
 
+GOV.UK One Login will only accept public keys generated using the RSA public key algorithm.
+
 ## Create a key pair 
 
 You can create a key pair using [OpenSSL](https://openssl-library.org/).


### PR DESCRIPTION
## Why

To clarify to RPs that they can only use keys generated using the RSA algorithm

## What

Addition of 1 sentence to add the clarification

## Technical writer support

Yes

## How to review

N/A

## Changelog

This is a small change that does not require a changelog update

## Confirm

- [ Y] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ N] Where there is any overlap I have updated or opened a PR for corresponding changes
