### PR TITLE
REX-1205: Migrate ALB WAF association to FMS custom policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -309,6 +309,10 @@ Resources:
         - Key: routing.http.drop_invalid_header_fields.enabled
           Value: "true"
       Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
+        - Key: CustomPolicy
+          Value: true
         - Key: Name
           Value: !Sub "${AWS::StackName}-SpokeApplicationLoadBalancer"
         - Key: Service
@@ -410,12 +414,6 @@ Resources:
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
-
-  SpokeWAFv2ACLAssociation:
-    Type: AWS::WAFv2::WebACLAssociation
-    Properties:
-      ResourceArn: !Ref SpokeApplicationLoadBalancer
-      WebACLArn: !ImportValue docs-waf-Waf-WebAcl-arn
 
   #
   # Spoke VPC - Application Load Balancing Ends Here


### PR DESCRIPTION
## Why

A 403 error was being returned when clicking the 'GOV.UK One Login integration environment' link in onboarding-examples/clients/nodejs/README.md. The link worked fine when copied directly into a browser. CloudWatch logs showed the block was caused by a WAF rule.

## What

The Application Load Balancer’s WAF association will no longer be managed directly by CloudFormation through AWS::WAFv2::WebACLAssociation. Instead, the association will be managed by AWS Firewall Manager (FMS) to provide centralized WAF management.

Removes the WAFv2ACLAssociation resource
Tags the spoke ALB with FMSRegionalPolicy: false and CustomPolicy: true so FMS applies the correct custom policy

## Technical writer support

Do you need a tech writer's support, for example to review your PR?

## How to review

Tell reviewers how to assess your changes.

## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [ ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
