### PR TITLE
AP-521 provide example of  argon2id hash

### DIFF
--- a/source/before-integrating/integrating-third-party-platform.html.md.erb
+++ b/source/before-integrating/integrating-third-party-platform.html.md.erb
@@ -74,6 +74,10 @@ Check the following parameters are in place:
 * type: Argon2id
 * output format: encoded hash
 
+Below is an example of an appropriately generated encoded hash:
+
+* $argon2id$v=19$m=16,t=2,p=1$aFhiNHJ0MEtqdExwN0RzYWJnM253NHpLYXcwLzNDSmtvQXUwdDkrVjJpdldDVDBJbFZ0UzNMZFNzUDJ3RDJaNFN2RXFyM0hBQzVkMFMwQjRlcVBpeEE9PQ$guPgJMtUpS40yrrPA5V5Bw
+
 ### Email the Argon2id formatted string to GOV.UK One Login
 
 1. Open a new email and leave the email subject blank. 

--- a/source/before-integrating/integrating-third-party-platform.html.md.erb
+++ b/source/before-integrating/integrating-third-party-platform.html.md.erb
@@ -76,7 +76,7 @@ Check the following parameters are in place:
 
 Below is an example of an appropriately generated encoded hash:
 
-* $argon2id$v=19$m=16,t=2,p=1$aFhiNHJ0MEtqdExwN0RzYWJnM253NHpLYXcwLzNDSmtvQXUwdDkrVjJpdldDVDBJbFZ0UzNMZFNzUDJ3RDJaNFN2RXFyM0hBQzVkMFMwQjRlcVBpeEE9PQ$guPgJMtUpS40yrrPA5V5Bw
+* `$argon2id$v=19$m=16,t=2,p=1$aFhiNHJ0MEtqdExwN0RzYWJnM253NHpLYXcwLzNDSmtvQXUwdDkrVjJpdldDVDBJbFZ0UzNMZFNzUDJ3RDJaNFN2RXFyM0hBQzVkMFMwQjRlcVBpeEE9PQ$guPgJMtUpS40yrrPA5V5Bw`
 
 ### Email the Argon2id formatted string to GOV.UK One Login
 


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/AP-521

## Why

To clarify the expected format of clients secrets that are provided to One Login

## What

Provision of an example of a valid Argon2id encoded client secret hash

## Technical writer support

As discussed with @ImogenCraigmile,  the example encoded hash is quite long, is there a better way of displaying it.

## How to review

Tell reviewers how to assess your changes.

## Changelog

This is a minor clarification that does not require a change log update

## Confirm

- [ Y] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [Y ] Where there is any overlap I have updated or opened a PR for corresponding changes
