### PR TITLE
REX:-1161: Switch DNS records to point to new Spoke VPC load balancer. 

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -55,8 +55,8 @@ Resources:
       Type: A
       HostedZoneId: !ImportValue TechDocsPublicHostedZoneId
       AliasTarget:
-        DNSName: !GetAtt SpokeApplicationLoadBalancer.DNSName
-        HostedZoneId: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
 
   TechDocsCertificate:
     Type: AWS::CertificateManager::Certificate
@@ -76,8 +76,8 @@ Resources:
       Type: A
       HostedZoneId: !ImportValue DocsSigninPublicHostedZoneId
       AliasTarget:
-        DNSName: !GetAtt SpokeApplicationLoadBalancer.DNSName
-        HostedZoneId: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
 
   #
   # Fargate cluster


### PR DESCRIPTION
## Why

Migrating VPC bound resources from the VPC to a SpokeVPC.

## What

Updates the DNS alias records for TechDocs and DocsSignin to point to the new ApplicationLoadBalancer in the Spoke VPC, replacing references to the old SpokeApplicationLoadBalancer. This is part of the migration of VPC-bound resources to the new Spoke VPC.


## Technical writer support

Do you need a tech writer's support, for example to review your PR?

## How to review

Tell reviewers how to assess your changes.

## Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb`  under the heading 'Documentation updates'.

## Confirm

- [ ] I have checked if any docs change here also requires updates to other repositories (ADRs / RFCs, README.md, Team Manual, elsewhere in these docs)
- [ ] Where there is any overlap I have updated or opened a PR for corresponding changes
